### PR TITLE
feat(Fws-38): Ability To Create A Coach Note

### DIFF
--- a/fitwsarah_frontend/public/LanguageContext/en/adminCreateCoachNotes.json
+++ b/fitwsarah_frontend/public/LanguageContext/en/adminCreateCoachNotes.json
@@ -1,0 +1,14 @@
+{
+  "User ID": "User ID",
+  "Content (EN)": "Content (EN)",
+  "Content (FR)": "Content (FR)",
+  "Create Coach Note": "Create Coach Note",
+  "back": "Back",
+  "coachNotes": "Coach Notes",
+  "coachNoteId": "Coach Note ID",
+  "userId": "User ID",
+  "content": "Content",
+  "delete": "Delete",
+  "details": "Details",
+  "username": "Username"
+}

--- a/fitwsarah_frontend/public/LanguageContext/en/trainerCreateCoachNotes.json
+++ b/fitwsarah_frontend/public/LanguageContext/en/trainerCreateCoachNotes.json
@@ -1,0 +1,14 @@
+{
+  "User ID": "User ID",
+  "Content (EN)": "Content (EN)",
+  "Content (FR)": "Content (FR)",
+  "Create Coach Note": "Create Coach Note",
+  "back": "Back",
+  "coachNotes": "Coach Notes",
+  "coachNoteId": "Coach Note ID",
+  "userId": "User ID",
+  "content": "Content",
+  "delete": "Delete",
+  "details": "Details",
+  "username": "Username"
+}

--- a/fitwsarah_frontend/public/LanguageContext/fr/adminCreateCoachNotes.json
+++ b/fitwsarah_frontend/public/LanguageContext/fr/adminCreateCoachNotes.json
@@ -1,0 +1,14 @@
+{
+  "User ID": "ID Utilisateur",
+  "Content (EN)": "Contenu (EN)",
+  "Content (FR)": "Contenu (FR)",
+  "Create Coach Note": "Créer Note d'Entraîneur",
+  "back": "Retour",
+  "coachNotes": "Notes de l'Entraîneur",
+  "coachNoteId": "ID de Note",
+  "userId": "ID Utilisateur",
+  "content": "Contenu",
+  "delete": "Supprimer",
+  "details": "Détails",
+  "username": "Nom d'Utilisateur"
+}

--- a/fitwsarah_frontend/public/LanguageContext/fr/trainerCreateCoachNotes.json
+++ b/fitwsarah_frontend/public/LanguageContext/fr/trainerCreateCoachNotes.json
@@ -1,0 +1,14 @@
+{
+  "User ID": "ID Utilisateur",
+  "Content (EN)": "Contenu (EN)",
+  "Content (FR)": "Contenu (FR)",
+  "Create Coach Note": "Créer Note d'Entraîneur",
+  "back": "Retour",
+  "coachNotes": "Notes de l'Entraîneur",
+  "coachNoteId": "ID de Note",
+  "userId": "ID Utilisateur",
+  "content": "Contenu",
+  "delete": "Supprimer",
+  "details": "Détails",
+  "username": "Nom d'Utilisateur"
+}

--- a/fitwsarah_frontend/src/App.js
+++ b/fitwsarah_frontend/src/App.js
@@ -22,6 +22,8 @@ import AdminFeedback from "./views/AdminPanelPage/Feedback";
 import { LanguageProvider } from './LanguageConfig/LanguageContext.js';
 import ClientInvoices from "./components/clientProfile/clientInvoices";
 import TrainerCoachNotes from "./views/PersonalTrainerPanel/TrainerCoachNotes";
+import AdminCreateCoachNote from "./views/AdminPanelPage/AdminCreateCoachNotes";
+import TrainerCreateCoachNotes from "./views/PersonalTrainerPanel/TrainerCreateCoachNote";
 
 function App() {
     return (
@@ -50,6 +52,9 @@ function App() {
                     <Route path="/invoices" element={<ClientInvoices/>}/>
                     <Route path="/adminCoachNotes" element={<AdminCoachNote/>}/>
                     <Route path="/trainerCoachNotes" element={<TrainerCoachNotes/>}/>
+                    <Route path="/AdminCreateCoachNotes" element={<AdminCreateCoachNote/>}/>
+                    <Route path="/TrainerCreateCoachNotes" element={<TrainerCreateCoachNotes/>}/>
+
                 </Routes>
             </Router>
         </LanguageProvider>

--- a/fitwsarah_frontend/src/LanguageConfig/i18n.js
+++ b/fitwsarah_frontend/src/LanguageConfig/i18n.js
@@ -16,7 +16,7 @@ i18n
     backend: {
         loadPath: '/LanguageContext/{{lng}}/{{ns}}.json',
     },
-    ns: ['footer', 'adminPanel', 'home', 'appointment', 'auth0', 'coachnotes', 'filter', 'nav', 'settings', 'account', 'contactMe', 'adminCreateInvoice', 'trainerCreateInvoice','adminCoachNotes'],
+    ns: ['footer', 'adminPanel', 'home', 'appointment', 'auth0', 'coachnotes', 'filter', 'nav', 'settings', 'account', 'contactMe', 'adminCreateInvoice', 'trainerCreateInvoice','adminCoachNotes', 'adminCreateCoachNotes'],
     defaultNS: 'home'
 
 });

--- a/fitwsarah_frontend/src/views/AdminPanelPage/AdminCoachNotes.js
+++ b/fitwsarah_frontend/src/views/AdminPanelPage/AdminCoachNotes.js
@@ -38,7 +38,7 @@ function AdminCoachNotes() {
 
     const getAllCoachNotes = () => {
 
-        fetch(`${process.env.REACT_APP_BASE_URL}/api/v1/coachnotes`, {
+        fetch(`${process.env.REACT_APP_DEVELOPMENT_URL}/api/v1/coachnotes`, {
             method: "GET",
             headers: new Headers({
                 Authorization: "Bearer " + accessToken,
@@ -71,12 +71,14 @@ function AdminCoachNotes() {
                     <div className="header-section">
                         <h1>{t('coachNotes')}</h1>
                     </div>
+                    <Link to="/AdminCreateCoachNotes" className="button back-button">Create Coach Note</Link>
                     <div className="table-responsive">
                         <table className="table">
                             <thead>
                             <tr>
                                 <th>{t('coachNoteId')}</th>
                                 <th>{t('userId')}</th>
+                                <th>{t('username')}</th>
                                 <th>{t('content')}</th>
                             </tr>
                             </thead>
@@ -85,6 +87,7 @@ function AdminCoachNotes() {
                                 <tr key={coachNotes.id}>
                                     <td>{coachNotes.coachNoteId}</td>
                                     <td>{coachNotes.userId}</td>
+                                    <td>{coachNotes.username}</td>
                                     <td>{coachNotes.content_EN}</td>
                                     <td>{coachNotes.content_FR}</td>
                                     <td>

--- a/fitwsarah_frontend/src/views/AdminPanelPage/AdminCoachNotes.js
+++ b/fitwsarah_frontend/src/views/AdminPanelPage/AdminCoachNotes.js
@@ -38,7 +38,7 @@ function AdminCoachNotes() {
 
     const getAllCoachNotes = () => {
 
-        fetch(`${process.env.REACT_APP_DEVELOPMENT_URL}/api/v1/coachnotes`, {
+        fetch(`${process.env.REACT_APP_BASE_URL}/api/v1/coachnotes`, {
             method: "GET",
             headers: new Headers({
                 Authorization: "Bearer " + accessToken,

--- a/fitwsarah_frontend/src/views/AdminPanelPage/AdminCreateCoachNotes.css
+++ b/fitwsarah_frontend/src/views/AdminPanelPage/AdminCreateCoachNotes.css
@@ -1,0 +1,83 @@
+.admin-invoices {
+    max-width: 600px;
+    margin: 40px auto;
+    padding: 20px;
+    background: #fff;
+    border-radius: 10px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    font-family: 'Arial', sans-serif;
+}
+
+.admin-invoices form {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.admin-invoices label {
+    font-size: 0.9em;
+    color: #333;
+    margin-bottom: 5px;
+}
+
+.admin-invoices input[type="text"],
+.admin-invoices input[type="number"],
+.admin-invoices select,
+.admin-invoices .MuiTextField-root {
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 0.9em;
+    color: #333;
+}
+
+.admin-invoices button {
+    padding: 10px 20px;
+    background-color: #422e37;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.9em;
+    transition: background-color 0.3s;
+}
+
+.admin-invoices button:hover {
+    background-color: #422e37;
+}
+
+/* Adjustments for the DateTimePicker */
+.admin-invoices .MuiTextField-root {
+    width: 100%;
+}
+
+/* Style adjustments for the slider */
+.admin-invoices input[type="range"] {
+    -webkit-appearance: none;
+    width: 100%;
+    height: 8px;
+    background: #ddd;
+    border-radius: 5px;
+    outline: none;
+    opacity: 0.7;
+    -webkit-transition: .2s;
+    transition: opacity .2s;
+}
+
+.admin-invoices input[type="range"]::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 20px;
+    height: 20px;
+    background: #422e37;
+    cursor: pointer;
+    border-radius: 50%;
+}
+
+.admin-invoices input[type="range"]::-moz-range-thumb {
+    width: 20px;
+    height: 20px;
+    background: #422e37;
+    cursor: pointer;
+    border-radius: 50%;
+}

--- a/fitwsarah_frontend/src/views/AdminPanelPage/AdminCreateCoachNotes.js
+++ b/fitwsarah_frontend/src/views/AdminPanelPage/AdminCreateCoachNotes.js
@@ -36,7 +36,7 @@ function AdminCreateCoachNotes() {
 
     const fetchAllAccounts = async () => {
         try {
-            const response = await fetch(`${process.env.REACT_APP_DEVELOPMENT_URL}/api/v1/accounts`, {
+            const response = await fetch(`${process.env.REACT_APP_BASE_URL}/api/v1/accounts`, {
                 method: "GET",
                 headers: {
                     Authorization: `Bearer ${accessToken}`,
@@ -76,7 +76,7 @@ function AdminCreateCoachNotes() {
             content_FR: newCoachNote.content_FR,
         };
         try {
-            const response = await fetch(`${process.env.REACT_APP_DEVELOPMENT_URL}/api/v1/coachnotes`, {
+            const response = await fetch(`${process.env.REACT_APP_BASE_URL}/api/v1/coachnotes`, {
                 method: "POST",
                 headers: {
                     Authorization: `Bearer ${accessToken}`,

--- a/fitwsarah_frontend/src/views/AdminPanelPage/AdminCreateCoachNotes.js
+++ b/fitwsarah_frontend/src/views/AdminPanelPage/AdminCreateCoachNotes.js
@@ -1,0 +1,120 @@
+import { useState, useEffect } from "react";
+import { useNavigate } from 'react-router-dom';
+import './AdminCreateCoachNotes.css';
+import { useGetAccessToken } from "../../components/authentication/authUtils";
+import { useTranslation } from "react-i18next";
+
+function AdminCreateCoachNotes() {
+    const navigate = useNavigate();
+    const [accessToken, setAccessToken] = useState(null);
+    const getAccessToken = useGetAccessToken();
+    const [accounts, setAccounts] = useState([]);
+    const [newCoachNote, setNewCoachNote] = useState({
+        accountId: '', // Added to hold the selected account's ID
+        userId: '',
+        username: '',
+        content_EN: '',
+        content_FR: '',
+    });
+
+    const { t } = useTranslation('trainerCreateCoachNotes');
+
+    useEffect(() => {
+        const fetchToken = async () => {
+            const token = await getAccessToken();
+            if (token) setAccessToken(token);
+        };
+
+        fetchToken();
+    }, [getAccessToken]);
+
+    useEffect(() => {
+        if (accessToken) {
+            fetchAllAccounts();
+        }
+    }, [accessToken]);
+
+    const fetchAllAccounts = async () => {
+        try {
+            const response = await fetch(`${process.env.REACT_APP_DEVELOPMENT_URL}/api/v1/accounts`, {
+                method: "GET",
+                headers: {
+                    Authorization: `Bearer ${accessToken}`,
+                    'Content-Type': 'application/json'
+                }
+            });
+            const data = await response.json();
+            if (!response.ok) throw new Error('Network response was not ok');
+            setAccounts(data);
+        } catch (error) {
+            console.error("Error fetching accounts:", error);
+        }
+    };
+
+    const handleInputChange = (e) => {
+        setNewCoachNote({ ...newCoachNote, [e.target.name]: e.target.value });
+    };
+
+    const handleUsernameChange = (e) => {
+        const selectedUsername = e.target.value;
+        const selectedAccount = accounts.find(account => account.username === selectedUsername);
+        setNewCoachNote({
+            ...newCoachNote,
+            username: selectedUsername,
+            accountId: selectedAccount ? selectedAccount.accountId : '',
+            userId: selectedAccount ? selectedAccount.userId : ''
+        });
+    };
+
+    const createCoachNote = async (event) => {
+        event.preventDefault();
+        const coachNoteData = {
+            accountId: newCoachNote.accountId,
+            userId: newCoachNote.userId,
+            username: newCoachNote.username,
+            content_EN: newCoachNote.content_EN,
+            content_FR: newCoachNote.content_FR,
+        };
+        try {
+            const response = await fetch(`${process.env.REACT_APP_DEVELOPMENT_URL}/api/v1/coachnotes`, {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${accessToken}`,
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(coachNoteData)
+            });
+            if (!response.ok) throw new Error('Network response was not ok');
+            navigate("/adminCoachNotes");
+        } catch (error) {
+            console.error('Error creating coach note:', error);
+        }
+    };
+
+    return (
+        <div className="admin-invoices">
+            <form onSubmit={createCoachNote}>
+                {/* Username Dropdown */}
+                <label htmlFor="username">{t('Username:')}</label>
+                <select id="username" name="username" value={newCoachNote.username} onChange={handleUsernameChange}>
+                    <option value="">Select a username</option>
+                    {accounts.map(account => (
+                        <option key={account.id} value={account.username}>{account.username}</option>
+                    ))}
+                </select>
+
+                {/* Content (EN) */}
+                <label htmlFor="content_EN">{t('Content (EN)')}</label>
+                <textarea id="content_EN" name="content_EN" value={newCoachNote.content_EN} onChange={handleInputChange}></textarea>
+
+                {/* Content (FR) */}
+                <label htmlFor="content_FR">{t('Content (FR)')}</label>
+                <textarea id="content_FR" name="content_FR" value={newCoachNote.content_FR} onChange={handleInputChange}></textarea>
+
+                <button type="submit">{t('Create Coach Note')}</button>
+            </form>
+        </div>
+    );
+}
+
+export default AdminCreateCoachNotes;

--- a/fitwsarah_frontend/src/views/PersonalTrainerPanel/TrainerCoachNotes.js
+++ b/fitwsarah_frontend/src/views/PersonalTrainerPanel/TrainerCoachNotes.js
@@ -38,7 +38,7 @@ function TrainerCoachNotes() {
 
     const getAllCoachNotes = () => {
 
-        fetch(`${process.env.REACT_APP_BASE_URL}/api/v1/coachnotes`, {
+        fetch(`${process.env.REACT_APP_DEVELOPMENT_URL}/api/v1/coachnotes`, {
             method: "GET",
             headers: new Headers({
                 Authorization: "Bearer " + accessToken,
@@ -71,12 +71,14 @@ function TrainerCoachNotes() {
                     <div className="header-section">
                         <h1>{t('coachNotes')}</h1>
                     </div>
+                    <Link to="/TrainerCreateCoachNotes" className="button back-button">Create Coach Note</Link>
                     <div className="table-responsive">
                         <table className="table">
                             <thead>
                             <tr>
                                 <th>{t('coachNoteId')}</th>
                                 <th>{t('userId')}</th>
+                                <th>{t('username')}</th>
                                 <th>{t('content')}</th>
                             </tr>
                             </thead>
@@ -85,6 +87,7 @@ function TrainerCoachNotes() {
                                 <tr key={coachNotes.id}>
                                     <td>{coachNotes.coachNoteId}</td>
                                     <td>{coachNotes.userId}</td>
+                                    <td>{coachNotes.username}</td>
                                     <td>{coachNotes.content_EN}</td>
                                     <td>{coachNotes.content_FR}</td>
                                     <td>

--- a/fitwsarah_frontend/src/views/PersonalTrainerPanel/TrainerCoachNotes.js
+++ b/fitwsarah_frontend/src/views/PersonalTrainerPanel/TrainerCoachNotes.js
@@ -38,7 +38,7 @@ function TrainerCoachNotes() {
 
     const getAllCoachNotes = () => {
 
-        fetch(`${process.env.REACT_APP_DEVELOPMENT_URL}/api/v1/coachnotes`, {
+        fetch(`${process.env.REACT_APP_BASE_URL}/api/v1/coachnotes`, {
             method: "GET",
             headers: new Headers({
                 Authorization: "Bearer " + accessToken,

--- a/fitwsarah_frontend/src/views/PersonalTrainerPanel/TrainerCreateCoachNote.css
+++ b/fitwsarah_frontend/src/views/PersonalTrainerPanel/TrainerCreateCoachNote.css
@@ -1,0 +1,83 @@
+.admin-invoices {
+    max-width: 600px;
+    margin: 40px auto;
+    padding: 20px;
+    background: #fff;
+    border-radius: 10px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    font-family: 'Arial', sans-serif;
+}
+
+.admin-invoices form {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.admin-invoices label {
+    font-size: 0.9em;
+    color: #333;
+    margin-bottom: 5px;
+}
+
+.admin-invoices input[type="text"],
+.admin-invoices input[type="number"],
+.admin-invoices select,
+.admin-invoices .MuiTextField-root {
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 0.9em;
+    color: #333;
+}
+
+.admin-invoices button {
+    padding: 10px 20px;
+    background-color: #422e37;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.9em;
+    transition: background-color 0.3s;
+}
+
+.admin-invoices button:hover {
+    background-color: #422e37;
+}
+
+/* Adjustments for the DateTimePicker */
+.admin-invoices .MuiTextField-root {
+    width: 100%;
+}
+
+/* Style adjustments for the slider */
+.admin-invoices input[type="range"] {
+    -webkit-appearance: none;
+    width: 100%;
+    height: 8px;
+    background: #ddd;
+    border-radius: 5px;
+    outline: none;
+    opacity: 0.7;
+    -webkit-transition: .2s;
+    transition: opacity .2s;
+}
+
+.admin-invoices input[type="range"]::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 20px;
+    height: 20px;
+    background: #422e37;
+    cursor: pointer;
+    border-radius: 50%;
+}
+
+.admin-invoices input[type="range"]::-moz-range-thumb {
+    width: 20px;
+    height: 20px;
+    background: #422e37;
+    cursor: pointer;
+    border-radius: 50%;
+}

--- a/fitwsarah_frontend/src/views/PersonalTrainerPanel/TrainerCreateCoachNote.js
+++ b/fitwsarah_frontend/src/views/PersonalTrainerPanel/TrainerCreateCoachNote.js
@@ -1,0 +1,120 @@
+import { useState, useEffect } from "react";
+import { useNavigate } from 'react-router-dom';
+import './TrainerCreateCoachNote.css';
+import { useGetAccessToken } from "../../components/authentication/authUtils";
+import { useTranslation } from "react-i18next";
+
+function TrainerCreateCoachNotes() {
+    const navigate = useNavigate();
+    const [accessToken, setAccessToken] = useState(null);
+    const getAccessToken = useGetAccessToken();
+    const [accounts, setAccounts] = useState([]);
+    const [newCoachNote, setNewCoachNote] = useState({
+        accountId: '', // Added to hold the selected account's ID
+        userId: '',
+        username: '',
+        content_EN: '',
+        content_FR: '',
+    });
+
+    const { t } = useTranslation('adminCreateCoachNotes');
+
+    useEffect(() => {
+        const fetchToken = async () => {
+            const token = await getAccessToken();
+            if (token) setAccessToken(token);
+        };
+
+        fetchToken();
+    }, [getAccessToken]);
+
+    useEffect(() => {
+        if (accessToken) {
+            fetchAllAccounts();
+        }
+    }, [accessToken]);
+
+    const fetchAllAccounts = async () => {
+        try {
+            const response = await fetch(`${process.env.REACT_APP_DEVELOPMENT_URL}/api/v1/accounts`, {
+                method: "GET",
+                headers: {
+                    Authorization: `Bearer ${accessToken}`,
+                    'Content-Type': 'application/json'
+                }
+            });
+            const data = await response.json();
+            if (!response.ok) throw new Error('Network response was not ok');
+            setAccounts(data);
+        } catch (error) {
+            console.error("Error fetching accounts:", error);
+        }
+    };
+
+    const handleInputChange = (e) => {
+        setNewCoachNote({ ...newCoachNote, [e.target.name]: e.target.value });
+    };
+
+    const handleUsernameChange = (e) => {
+        const selectedUsername = e.target.value;
+        const selectedAccount = accounts.find(account => account.username === selectedUsername);
+        setNewCoachNote({
+            ...newCoachNote,
+            username: selectedUsername,
+            accountId: selectedAccount ? selectedAccount.accountId : '',
+            userId: selectedAccount ? selectedAccount.userId : ''
+        });
+    };
+
+    const createCoachNote = async (event) => {
+        event.preventDefault();
+        const coachNoteData = {
+            accountId: newCoachNote.accountId,
+            userId: newCoachNote.userId,
+            username: newCoachNote.username,
+            content_EN: newCoachNote.content_EN,
+            content_FR: newCoachNote.content_FR,
+        };
+        try {
+            const response = await fetch(`${process.env.REACT_APP_DEVELOPMENT_URL}/api/v1/coachnotes`, {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${accessToken}`,
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(coachNoteData)
+            });
+            if (!response.ok) throw new Error('Network response was not ok');
+            navigate("/trainerCoachNotes");
+        } catch (error) {
+            console.error('Error creating coach note:', error);
+        }
+    };
+
+    return (
+        <div className="admin-invoices">
+            <form onSubmit={createCoachNote}>
+                {/* Username Dropdown */}
+                <label htmlFor="username">{t('Username:')}</label>
+                <select id="username" name="username" value={newCoachNote.username} onChange={handleUsernameChange}>
+                    <option value="">Select a username</option>
+                    {accounts.map(account => (
+                        <option key={account.id} value={account.username}>{account.username}</option>
+                    ))}
+                </select>
+
+                {/* Content (EN) */}
+                <label htmlFor="content_EN">{t('Content (EN)')}</label>
+                <textarea id="content_EN" name="content_EN" value={newCoachNote.content_EN} onChange={handleInputChange}></textarea>
+
+                {/* Content (FR) */}
+                <label htmlFor="content_FR">{t('Content (FR)')}</label>
+                <textarea id="content_FR" name="content_FR" value={newCoachNote.content_FR} onChange={handleInputChange}></textarea>
+
+                <button type="submit">{t('Create Coach Note')}</button>
+            </form>
+        </div>
+    );
+}
+
+export default TrainerCreateCoachNotes;

--- a/fitwsarah_frontend/src/views/PersonalTrainerPanel/TrainerCreateCoachNote.js
+++ b/fitwsarah_frontend/src/views/PersonalTrainerPanel/TrainerCreateCoachNote.js
@@ -36,7 +36,7 @@ function TrainerCreateCoachNotes() {
 
     const fetchAllAccounts = async () => {
         try {
-            const response = await fetch(`${process.env.REACT_APP_DEVELOPMENT_URL}/api/v1/accounts`, {
+            const response = await fetch(`${process.env.REACT_APP_BASE_URL}/api/v1/accounts`, {
                 method: "GET",
                 headers: {
                     Authorization: `Bearer ${accessToken}`,
@@ -76,7 +76,7 @@ function TrainerCreateCoachNotes() {
             content_FR: newCoachNote.content_FR,
         };
         try {
-            const response = await fetch(`${process.env.REACT_APP_DEVELOPMENT_URL}/api/v1/coachnotes`, {
+            const response = await fetch(`${process.env.REACT_APP_BASE_URL}/api/v1/coachnotes`, {
                 method: "POST",
                 headers: {
                     Authorization: `Bearer ${accessToken}`,

--- a/src/main/java/com/fitwsarah/fitwsarah/coachnotesubdomain/businesslayer/CoachNoteService.java
+++ b/src/main/java/com/fitwsarah/fitwsarah/coachnotesubdomain/businesslayer/CoachNoteService.java
@@ -1,5 +1,6 @@
 package com.fitwsarah.fitwsarah.coachnotesubdomain.businesslayer;
 
+import com.fitwsarah.fitwsarah.coachnotesubdomain.presentationlayer.CoachNoteRequestModel;
 import com.fitwsarah.fitwsarah.coachnotesubdomain.presentationlayer.CoachNoteResponseModel;
 
 import java.util.List;
@@ -9,4 +10,6 @@ public interface CoachNoteService {
     List<CoachNoteResponseModel> getCoachNoteByUserId(String userId);
 
     List<CoachNoteResponseModel> getAllCoachNotes();
+
+    CoachNoteResponseModel addCoachNote(CoachNoteRequestModel coachNoteRequestModel);
 }

--- a/src/main/java/com/fitwsarah/fitwsarah/coachnotesubdomain/businesslayer/CoachNoteServiceImpl.java
+++ b/src/main/java/com/fitwsarah/fitwsarah/coachnotesubdomain/businesslayer/CoachNoteServiceImpl.java
@@ -1,8 +1,12 @@
 package com.fitwsarah.fitwsarah.coachnotesubdomain.businesslayer;
 
+import com.fitwsarah.fitwsarah.appointmentsubdomain.datalayer.Appointment;
+import com.fitwsarah.fitwsarah.appointmentsubdomain.datalayer.Status;
+import com.fitwsarah.fitwsarah.coachnotesubdomain.datalayer.CoachNote;
 import com.fitwsarah.fitwsarah.coachnotesubdomain.datalayer.CoachNoteRepository;
 import com.fitwsarah.fitwsarah.coachnotesubdomain.datamapperlayer.CoachNoteRequestMapper;
 import com.fitwsarah.fitwsarah.coachnotesubdomain.datamapperlayer.CoachNoteResponseMapper;
+import com.fitwsarah.fitwsarah.coachnotesubdomain.presentationlayer.CoachNoteRequestModel;
 import com.fitwsarah.fitwsarah.coachnotesubdomain.presentationlayer.CoachNoteResponseModel;
 import org.springframework.stereotype.Service;
 
@@ -32,6 +36,13 @@ public class CoachNoteServiceImpl implements CoachNoteService{
     @Override
     public List<CoachNoteResponseModel> getAllCoachNotes() {
         return coachNoteResponseMapper.entityListToResponseModelList(coachNoteRepository.findAll());
+    }
+
+    @Override
+    public CoachNoteResponseModel addCoachNote(CoachNoteRequestModel coachNoteRequestModel) {
+        CoachNote coachNote = coachNoteRequestMapper.requestModelToEntity(coachNoteRequestModel);
+        CoachNote savedCoachNote = coachNoteRepository.save(coachNote);
+        return coachNoteResponseMapper.entityToResponseModel(savedCoachNote);
     }
 
 }

--- a/src/main/java/com/fitwsarah/fitwsarah/coachnotesubdomain/datalayer/CoachNote.java
+++ b/src/main/java/com/fitwsarah/fitwsarah/coachnotesubdomain/datalayer/CoachNote.java
@@ -15,18 +15,21 @@ public class CoachNote {
 
     @Embedded
     private CoachNoteIdentifier coachNoteIdentifier;
-
+    private String accountId;
     private String userId;
-
+    private String username;
     private String content_EN;
     private String content_FR;
 
     public CoachNote(){
         this.coachNoteIdentifier = new CoachNoteIdentifier();
     }
-    public CoachNote (String userId, String content_EN, String content_FR){
+
+    public CoachNote(String accountId, String userId, String username, String content_EN, String content_FR) {
         this.coachNoteIdentifier = new CoachNoteIdentifier();
+        this.accountId = accountId;
         this.userId = userId;
+        this.username = username;
         this.content_EN = content_EN;
         this.content_FR = content_FR;
     }

--- a/src/main/java/com/fitwsarah/fitwsarah/coachnotesubdomain/presentationlayer/CoachNoteController.java
+++ b/src/main/java/com/fitwsarah/fitwsarah/coachnotesubdomain/presentationlayer/CoachNoteController.java
@@ -1,10 +1,7 @@
 package com.fitwsarah.fitwsarah.coachnotesubdomain.presentationlayer;
 
 import com.fitwsarah.fitwsarah.coachnotesubdomain.businesslayer.CoachNoteService;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -27,4 +24,8 @@ public class CoachNoteController {
         return coachNoteService.getAllCoachNotes();
     }
 
+    @PostMapping()
+    public CoachNoteResponseModel addCoachNote(@RequestBody CoachNoteRequestModel coachNoteRequestModel){
+        return coachNoteService.addCoachNote(coachNoteRequestModel);
+    }
 }

--- a/src/main/java/com/fitwsarah/fitwsarah/coachnotesubdomain/presentationlayer/CoachNoteRequestModel.java
+++ b/src/main/java/com/fitwsarah/fitwsarah/coachnotesubdomain/presentationlayer/CoachNoteRequestModel.java
@@ -10,7 +10,9 @@ import lombok.Value;
 @AllArgsConstructor(access = AccessLevel.PUBLIC)
 public class CoachNoteRequestModel {
 
+     String accountId;
      String userId;
+     String username;
      String content_EN;
      String content_FR;
 }

--- a/src/main/java/com/fitwsarah/fitwsarah/coachnotesubdomain/presentationlayer/CoachNoteResponseModel.java
+++ b/src/main/java/com/fitwsarah/fitwsarah/coachnotesubdomain/presentationlayer/CoachNoteResponseModel.java
@@ -11,7 +11,9 @@ import lombok.Value;
 public class CoachNoteResponseModel {
 
     String coachNoteId;
+    String accountId;
     String userId;
+    String username;
     String content_EN;
     String content_FR;
 

--- a/src/main/resources/data-mysql.sql
+++ b/src/main/resources/data-mysql.sql
@@ -58,9 +58,9 @@ INSERT INTO availabilities (availability_id, available, account_id, datetime) VA
 ('uuid-avail4', 0, 'uuid-acc4', '2023-12-04 14:00:00'),
 ('uuid-avail5', 1, 'uuid-acc5', '2023-12-05 16:30:00');
 
-INSERT INTO coach_notes (coach_note_id, user_id, content_en, content_fr) VALUES
-('1', '65b9b977d5fa901a57937bc3', 'Keep up the great work with your training!', 'Continuez votre excellent travail avec votre entraînement !'),
-('2', '65b9b977d5fa901a57937bc3', 'Remember to stay hydrated during workouts.', 'oubliez pas de rester hydraté pendant les entraînements.'),
-('3', '65b9b977d5fa901a57937bc3', 'Excellent progress on your last session!', 'Excellents progrès lors de votre dernière séance !'),
-('4', '65b16a01c0705bb1bf4a2bb8', 'Try to increase your running distance gradually.', 'Essayez d''augmenter progressivement votre distance de course.'),
-('5', '65b16a01c0705bb1bf4a2bb8', 'Focus on maintaining a balanced diet.', 'Concentrez-vous sur le maintien d''une alimentation équilibrée.');
+INSERT INTO coach_notes (coach_note_id, account_id, user_id, username, content_en, content_fr) VALUES
+                                                                                                   ('1', 'uuid-acc1', '65b9b977d5fa901a57937bc3', 'johnsmith', 'Keep up the great work with your training!', 'Continuez votre excellent travail avec votre entraînement !'),
+                                                                                                   ('2', 'uuid-acc2', '65b9b977d5fa901a57937bc3', 'emilyjones', 'Remember to stay hydrated during workouts.', 'Noubliez pas de rester hydraté pendant les entraînements.'),
+('3', 'uuid-acc3', '101188348963819843921', 'michaelbrown', 'Excellent progress on your last session!', 'Excellents progrès lors de votre dernière séance !'),
+('4', 'uuid-acc4', '101188348963819843921', 'sarahwhite', 'Try to increase your running distance gradually.', 'Essayez d''augmenter progressivement votre distance de course.'),
+('5', 'uuid-acc5', '101188348963819843921', 'davidjohnson', 'Focus on maintaining a balanced diet.', 'Concentrez-vous sur le maintien d''une alimentation équilibrée.');

--- a/src/main/resources/schema-mysql.sql
+++ b/src/main/resources/schema-mysql.sql
@@ -83,7 +83,9 @@ create table if not exists availabilities(
 create table if not exists coach_notes(
     id INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY,
     coach_note_id VARCHAR(36) NOT NULL,
+    account_id VARCHAR(36) NOT NULL,
     user_id VARCHAR(36) NOT NULL,
+    username VARCHAR(50),
     content_en VARCHAR(120) NOT NULL,
     content_fr VARCHAR(120) NOT NULL
 );

--- a/src/test/java/EndToEndTesting.java
+++ b/src/test/java/EndToEndTesting.java
@@ -818,5 +818,4 @@ public class EndToEndTesting {
         sleep(1000);
     }
 
-
 }

--- a/src/test/java/EndToEndTesting.java
+++ b/src/test/java/EndToEndTesting.java
@@ -599,11 +599,6 @@ public class EndToEndTesting {
 
         sleep(1000);
 
-        SelenideElement ileBtn = $("a[href='/trainerCreateInvoices']");
-        ileBtn.click();
-
-        sleep(1000);
-
         SelenideElement usernameDropdown = $("select[name='username']");
         usernameDropdown.selectOption("desired_username");
 
@@ -769,4 +764,59 @@ public class EndToEndTesting {
         sleep(1000);
 
     }
+
+
+    @Test
+    public void addCoachNoteTrainerPanel(){
+        open("http://localhost:3000/");
+        SelenideElement loginBtn = $("button[class='login-button']");
+        loginBtn.click();
+
+        sleep(1000);
+        SelenideElement emailInput = $("input[name='username']");
+        emailInput.setValue("admin@admin.com");
+
+        sleep(1000);
+
+        SelenideElement passwordInput = $("input[name='password']");
+        passwordInput.setValue("Password1");
+
+        sleep(1000);
+
+        SelenideElement continueButton = $("button[name='action']");
+        executeJavaScript("arguments[0].click();", continueButton);
+
+        sleep(1000);
+
+        SelenideElement adminPanelBtn = $("a[href='/trainerPanel']");
+        adminPanelBtn.click();
+
+        sleep(1000);
+
+        SelenideElement profileBtn = $("a[href='/trainerCoachNotes']");
+        profileBtn.click();
+
+        sleep(1000);
+
+        SelenideElement pileBtn = $("a[href='/TrainerCreateCoachNotes']");
+        pileBtn.click();
+
+        sleep(1000);
+
+        SelenideElement usernameDropdown = $("select[name='username']");
+        usernameDropdown.selectOption("desired_username");
+
+        SelenideElement paymentTypeInput = $("input[name='content_EN']");
+        paymentTypeInput.setValue("content");
+
+        SelenideElement paymentTypeInpute = $("input[name='content_FR']");
+        paymentTypeInput.setValue("contenu");
+
+        SelenideElement createInvoiceButton = $("button[type='submit']");
+        createInvoiceButton.click();
+
+        sleep(1000);
+    }
+
+
 }

--- a/src/test/java/com/fitwsarah/fitwsarah/appointmentsubdomain/presentationlayer/AppointmentControllerUnitTest.java
+++ b/src/test/java/com/fitwsarah/fitwsarah/appointmentsubdomain/presentationlayer/AppointmentControllerUnitTest.java
@@ -171,6 +171,7 @@ class AppointmentControllerUnitTest {
         // Assert
         assertEquals(expectedResponse, result);
     }
+
 }
 
 

--- a/src/test/java/com/fitwsarah/fitwsarah/coachnotesubdomain/businesslayer/CoachNoteServiceImplTest.java
+++ b/src/test/java/com/fitwsarah/fitwsarah/coachnotesubdomain/businesslayer/CoachNoteServiceImplTest.java
@@ -1,9 +1,15 @@
 package com.fitwsarah.fitwsarah.coachnotesubdomain.businesslayer;
 
+import com.fitwsarah.fitwsarah.appointmentsubdomain.datalayer.Appointment;
+import com.fitwsarah.fitwsarah.appointmentsubdomain.datalayer.Status;
+import com.fitwsarah.fitwsarah.appointmentsubdomain.presentationlayer.AppointmentRequestModel;
+import com.fitwsarah.fitwsarah.appointmentsubdomain.presentationlayer.AppointmentResponseModel;
 import com.fitwsarah.fitwsarah.coachnotesubdomain.businesslayer.CoachNoteServiceImpl;
+import com.fitwsarah.fitwsarah.coachnotesubdomain.datalayer.CoachNote;
 import com.fitwsarah.fitwsarah.coachnotesubdomain.datalayer.CoachNoteRepository;
 import com.fitwsarah.fitwsarah.coachnotesubdomain.datamapperlayer.CoachNoteRequestMapper;
 import com.fitwsarah.fitwsarah.coachnotesubdomain.datamapperlayer.CoachNoteResponseMapper;
+import com.fitwsarah.fitwsarah.coachnotesubdomain.presentationlayer.CoachNoteRequestModel;
 import com.fitwsarah.fitwsarah.coachnotesubdomain.presentationlayer.CoachNoteResponseModel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,6 +23,8 @@ import java.util.List;
 
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ActiveProfiles("test")
@@ -42,7 +50,7 @@ public class CoachNoteServiceImplTest {
     @Test
     public void getCoachNoteByUserIdReturnsExpectedResult() {
         String userId = "testUserId";
-        List<CoachNoteResponseModel> expectedResponse = Collections.singletonList(new CoachNoteResponseModel("testId", "testUserId", "testNote", "testDate"));
+        List<CoachNoteResponseModel> expectedResponse = Collections.singletonList(new CoachNoteResponseModel("sadsads","testUserId", "testNote", "test","sdasda","asdasda"));
         when(coachNoteRepository.findCoachNoteByUserId(userId)).thenReturn(Collections.emptyList());
         when(coachNoteResponseMapper.entityListToResponseModelList(Collections.emptyList())).thenReturn(expectedResponse);
 
@@ -70,7 +78,7 @@ public class CoachNoteServiceImplTest {
 
     @Test
     public void getAllCoachNotesReturnsExpectedResult() {
-        List<CoachNoteResponseModel> expectedResponse = Collections.singletonList(new CoachNoteResponseModel("testId", "testUserId", "testNote", "testDate"));
+        List<CoachNoteResponseModel> expectedResponse = Collections.singletonList(new CoachNoteResponseModel("sadsads","testUserId", "testNote", "test","sdasda","asdasda"));
         when(coachNoteRepository.findAll()).thenReturn(Collections.emptyList());
         when(coachNoteResponseMapper.entityListToResponseModelList(Collections.emptyList())).thenReturn(expectedResponse);
 
@@ -78,4 +86,27 @@ public class CoachNoteServiceImplTest {
 
         assertEquals(expectedResponse, actualResponse);
     }
+
+    @Test
+    public void addCoachNoteReturnsExpectedResult() {
+
+        CoachNoteRequestModel requestModel = new CoachNoteRequestModel("testUserId", "testNote", "test","sdasda","asdasda");
+
+        CoachNote entity = mock(CoachNote.class);
+        CoachNoteResponseModel mockedResponse = new CoachNoteResponseModel("sadsads","testUserId", "testNote", "test","sdasda","asdasda");
+        when(coachNoteResponseMapper.entityToResponseModel(entity)).thenReturn(mockedResponse);
+        when(coachNoteRequestMapper.requestModelToEntity(requestModel)).thenReturn(entity);
+        when(coachNoteRepository.save(entity)).thenReturn(entity);
+
+        CoachNoteResponseModel result = coachNoteService.addCoachNote(requestModel);
+        assertNotNull(result);
+        assertNotNull(result.getCoachNoteId());
+        assertNotNull(result.getUserId());
+        assertNotNull(result.getAccountId());
+        assertNotNull(result.getUsername());
+        assertNotNull(result.getContent_EN());
+        assertNotNull(result.getContent_FR());
+
+    }
+
 }

--- a/src/test/java/com/fitwsarah/fitwsarah/coachnotesubdomain/presentationlayer/CoachNoteControllerIntegrationTest.java
+++ b/src/test/java/com/fitwsarah/fitwsarah/coachnotesubdomain/presentationlayer/CoachNoteControllerIntegrationTest.java
@@ -1,7 +1,10 @@
 package com.fitwsarah.fitwsarah.coachnotesubdomain.presentationlayer;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fitwsarah.fitwsarah.appointmentsubdomain.datalayer.Status;
+import com.fitwsarah.fitwsarah.appointmentsubdomain.presentationlayer.AppointmentRequestModel;
 import com.fitwsarah.fitwsarah.coachnotesubdomain.businesslayer.CoachNoteService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,6 +26,7 @@ import java.util.List;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.http.RequestEntity.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
@@ -34,7 +38,7 @@ public class CoachNoteControllerIntegrationTest {
     private MockMvc mockMvc;
     @MockBean
     private CoachNoteService coachNoteService;
-    private CoachNoteResponseModel coachNoteResponseModel = new CoachNoteResponseModel("coachNoteId", "testUserId", "testContent", "testDate");
+    private CoachNoteResponseModel coachNoteResponseModel = new CoachNoteResponseModel("sadsads","testUserId", "testNote", "test","sdasda","asdasda");
     private String testToken = "Bearer ";
     private List<CoachNoteResponseModel> coachNoteResponseModelList;
     private String testUserId = "testUserId";
@@ -67,6 +71,19 @@ public class CoachNoteControllerIntegrationTest {
                 .andExpect(status().isOk());
     }
 
+    @Test
+    public void addCoachNoteTest() throws Exception {
+        mockMvc.perform(post("/api/v1/coachnotes")
+                        .header("Authorization", testToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(new CoachNoteRequestModel("testAccountId", "testUserId", "testUsername", "testContent_EN", "testContent_FR"))))
+                .andExpect(status().isOk());
+    }
+
+    private String asJsonString(Object obj) throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        return objectMapper.writeValueAsString(obj);
+    }
 
     public String obtainAuthToken() throws Exception {
         RestTemplate restTemplate = new RestTemplate();

--- a/src/test/java/com/fitwsarah/fitwsarah/coachnotesubdomain/presentationlayer/CoachNoteControllerUnitTest.java
+++ b/src/test/java/com/fitwsarah/fitwsarah/coachnotesubdomain/presentationlayer/CoachNoteControllerUnitTest.java
@@ -31,7 +31,7 @@ public class CoachNoteControllerUnitTest {
     @Test
     public void getCoachNoteByUserIdTest() {
         String userId = "testUserId";
-        CoachNoteResponseModel coachNoteResponseModel = new CoachNoteResponseModel("coachNoteId", "testUserId", "testContent", "testDate");
+        CoachNoteResponseModel coachNoteResponseModel = new CoachNoteResponseModel("sadsads","testUserId", "testNote", "test","sdasda","asdasda");
         List<CoachNoteResponseModel> expectedResponse = Arrays.asList(coachNoteResponseModel);
 
         when(coachNoteService.getCoachNoteByUserId(userId)).thenReturn(expectedResponse);
@@ -43,12 +43,24 @@ public class CoachNoteControllerUnitTest {
 
     @Test
     public void getAllCoachNotesTest() {
-        CoachNoteResponseModel coachNoteResponseModel = new CoachNoteResponseModel("coachNoteId", "testUserId", "testContent", "testDate");
+        CoachNoteResponseModel coachNoteResponseModel = new CoachNoteResponseModel("sadsads","testUserId", "testNote", "test","sdasda","asdasda");
         List<CoachNoteResponseModel> expectedResponse = Arrays.asList(coachNoteResponseModel);
 
         when(coachNoteService.getAllCoachNotes()).thenReturn(expectedResponse);
 
         List<CoachNoteResponseModel> actualResponse = coachNoteController.getAllCoachNotes();
+
+        assertEquals(expectedResponse, actualResponse);
+    }
+
+    @Test
+    public void addCoachNoteTest() {
+        CoachNoteRequestModel coachNoteRequestModel = new CoachNoteRequestModel("testUserId", "testNote", "test","sdasda","asdasda");
+        CoachNoteResponseModel expectedResponse = new CoachNoteResponseModel("sadsads","testUserId", "testNote", "test","sdasda","asdasda");
+
+        when(coachNoteService.addCoachNote(coachNoteRequestModel)).thenReturn(expectedResponse);
+
+        CoachNoteResponseModel actualResponse = coachNoteController.addCoachNote(coachNoteRequestModel);
 
         assertEquals(expectedResponse, actualResponse);
     }


### PR DESCRIPTION
**JIRA: link to jira ticket**
https://champlainsaintlambert.atlassian.net/browse/FWS-38

**What is the ticket about and why are we making this change?**

This ticket concerns being able to create a coach note as a trainer/admin on a client. This is important because as a trainer you want to be able to add a coach note to a client after an appointment or to simply give them valuable information that a coach would want to give their client. 

**What are the various changes and what other modules do those changes affect?**
 
-3 types of testing
-Selenium Test
-backend for the addCoachNote
-Front end for the addCoachNote
-Added both Admin/Trainer CreateCoachNote form to be able to create the CoachNote
-Added the create button for both the trainer/admin that brings you to the create form.

**UI Change:**

Before Coach Note view:
![image](https://github.com/AlexeiTimbro/FitWSarah/assets/57909059/f64b6d03-96a2-4136-89e7-b3688c2e95d5)

After Coach Note View:
![image](https://github.com/AlexeiTimbro/FitWSarah/assets/57909059/1a3dab1e-f7af-461c-aa26-8c1addbe54c5)

After clicking Create CoachNote:
![image](https://github.com/AlexeiTimbro/FitWSarah/assets/57909059/51ef1e24-a280-446f-9b3f-29f3d62f4ba3)

After creating the Coach Note ( coach note added):
![image](https://github.com/AlexeiTimbro/FitWSarah/assets/57909059/b3ce8b83-0032-42cd-8f93-de5db3e79892)








