### PR TITLE
feat(Fws -04): Ability To Delete A Coach Note

### DIFF
--- a/fitwsarah_frontend/src/views/AdminPanelPage/AdminCoachNotes.css
+++ b/fitwsarah_frontend/src/views/AdminPanelPage/AdminCoachNotes.css
@@ -86,6 +86,19 @@ body {
     text-decoration: none;
     border: none;
 }
+.ddelete {
+    background-color: #d9534f;
+    display: inline-block;
+    padding: 8px 15px;
+    margin: 0 5px;
+    border-radius: 4px;
+    color: #fff;
+    font-size: 0.9em;
+    cursor: pointer;
+    text-align: center;
+    text-decoration: none;
+    border: none;
+}
 
 
 /* Responsive table styles */

--- a/fitwsarah_frontend/src/views/AdminPanelPage/AdminCoachNotes.js
+++ b/fitwsarah_frontend/src/views/AdminPanelPage/AdminCoachNotes.js
@@ -175,7 +175,7 @@ function AdminCoachNotes() {
                                         ) : (
                                             <>
                                             <button onClick={() => handleEditClick(coachNote)} className="blueButton">Edit</button>
-                                            <button onClick={() => handleDeleteClick(coachNote.coachNoteId)} className="cancelDelete">Delete</button>
+                                            <button onClick={() => handleDeleteClick(coachNote.coachNoteId)} className="ddelete">Delete</button>
                                             </>
                                             )}
                                     </td>

--- a/fitwsarah_frontend/src/views/AdminPanelPage/AdminCoachNotes.js
+++ b/fitwsarah_frontend/src/views/AdminPanelPage/AdminCoachNotes.js
@@ -91,6 +91,27 @@ function AdminCoachNotes() {
         setEditCoachNoteId(null);
     };
 
+    const handleDeleteClick = async (coachNoteId) => {
+        if (window.confirm('Are you sure you want to delete this coach note?')) {
+            try {
+                const response = await fetch(`${process.env.REACT_APP_BASE_URL}/api/v1/coachnotes/${coachNoteId}`, {
+                    method: "DELETE",
+                    headers: {
+                        Authorization: `Bearer ${accessToken}`,
+                    },
+                });
+
+                if (!response.ok) {
+                    throw new Error("Network response was not ok");
+                }
+
+                getAllCoachNotes();
+            } catch (error) {
+                console.error("Failed to delete coach note:", error);
+            }
+        }
+    };
+
     return (
         <div>
             {!isAuthenticated && <NavNotLoggedIn />}
@@ -152,8 +173,11 @@ function AdminCoachNotes() {
                                                 <button onClick={handleCancelClick} className="cancelDelete">Cancel</button>
                                             </>
                                         ) : (
+                                            <>
                                             <button onClick={() => handleEditClick(coachNote)} className="blueButton">Edit</button>
-                                        )}
+                                            <button onClick={() => handleDeleteClick(coachNote.coachNoteId)} className="cancelDelete">Delete</button>
+                                            </>
+                                            )}
                                     </td>
                                 </tr>
                             ))}

--- a/fitwsarah_frontend/src/views/PersonalTrainerPanel/TrainerCoachNotes.js
+++ b/fitwsarah_frontend/src/views/PersonalTrainerPanel/TrainerCoachNotes.js
@@ -104,6 +104,27 @@ function TrainerCoachNotes() {
         setEditCoachNoteId(null);
     };
 
+    const handleDeleteClick = async (coachNoteId) => {
+        if (window.confirm('Are you sure you want to delete this coach note?')) {
+            try {
+                const response = await fetch(`${process.env.REACT_APP_BASE_URL}/api/v1/coachnotes/${coachNoteId}`, {
+                    method: "DELETE",
+                    headers: {
+                        Authorization: `Bearer ${accessToken}`,
+                    },
+                });
+
+                if (!response.ok) {
+                    throw new Error("Network response was not ok");
+                }
+
+                getAllCoachNotes();
+            } catch (error) {
+                console.error("Failed to delete coach note:", error);
+            }
+        }
+    };
+
 
     return (
         <div>
@@ -167,7 +188,10 @@ function TrainerCoachNotes() {
                                                 <button onClick={handleCancelClick} className="cancelDelete">Cancel</button>
                                             </>
                                         ) : (
-                                            <button onClick={() => handleEditClick(coachNote)} className="blueButton">Edit</button>
+                                            <>
+                                                <button onClick={() => handleEditClick(coachNote)} className="blueButton">Edit</button>
+                                                <button onClick={() => handleDeleteClick(coachNote.coachNoteId)} className="cancelDelete">Delete</button>
+                                            </>
                                         )}
                                     </td>
                                 </tr>

--- a/src/main/java/com/fitwsarah/fitwsarah/coachnotesubdomain/businesslayer/CoachNoteService.java
+++ b/src/main/java/com/fitwsarah/fitwsarah/coachnotesubdomain/businesslayer/CoachNoteService.java
@@ -14,4 +14,6 @@ public interface CoachNoteService {
     CoachNoteResponseModel addCoachNote(CoachNoteRequestModel coachNoteRequestModel);
 
     CoachNoteResponseModel updateCoachNoteById(String coachNoteId, CoachNoteRequestModel coachNoteRequestModel);
+
+    void deleteCoachNoteById(String coachNoteId);
 }

--- a/src/main/java/com/fitwsarah/fitwsarah/coachnotesubdomain/businesslayer/CoachNoteServiceImpl.java
+++ b/src/main/java/com/fitwsarah/fitwsarah/coachnotesubdomain/businesslayer/CoachNoteServiceImpl.java
@@ -61,4 +61,17 @@ public class CoachNoteServiceImpl implements CoachNoteService{
         return coachNoteResponseMapper.entityToResponseModel(coachNote);
     }
 
+    @Override
+    public void deleteCoachNoteById(String coachNoteId) {
+
+        CoachNote coachNote = coachNoteRepository.findCoachNoteByCoachNoteIdentifier_CoachNoteId(coachNoteId);
+
+        if (coachNote == null) {
+            throw new EntityNotFoundException("Coach Note with ID " + coachNoteId + " not found");
+        }
+
+        coachNoteRepository.delete(coachNote);
+
+    }
+
 }

--- a/src/main/java/com/fitwsarah/fitwsarah/coachnotesubdomain/presentationlayer/CoachNoteController.java
+++ b/src/main/java/com/fitwsarah/fitwsarah/coachnotesubdomain/presentationlayer/CoachNoteController.java
@@ -33,4 +33,9 @@ public class CoachNoteController {
     public CoachNoteResponseModel updateCoachNoteById(@PathVariable String coachNoteId, @RequestBody CoachNoteRequestModel coachNoteRequestModel){
         return coachNoteService.updateCoachNoteById(coachNoteId, coachNoteRequestModel);
     }
+
+    @DeleteMapping("/{coachNoteId}")
+    public void deleteCoachNoteById(@PathVariable String coachNoteId){
+        coachNoteService.deleteCoachNoteById(coachNoteId);
+    }
 }

--- a/src/test/java/EndToEndTesting.java
+++ b/src/test/java/EndToEndTesting.java
@@ -961,4 +961,50 @@ public class EndToEndTesting {
         availabilitiesBtn.click();
 
     }
+
+
+    @Test
+    public void deleteCoachNoteTrainerPanel(){
+        open("http://localhost:3000/");
+        SelenideElement loginBtn = $("button[class='login-button']");
+        loginBtn.click();
+
+        sleep(1000);
+        SelenideElement emailInput = $("input[name='username']");
+        emailInput.setValue("admin@admin.com");
+
+        sleep(1000);
+
+        SelenideElement passwordInput = $("input[name='password']");
+        passwordInput.setValue("Password1");
+
+        sleep(1000);
+
+        SelenideElement continueButton = $("button[name='action']");
+        executeJavaScript("arguments[0].click();", continueButton);
+
+        sleep(1000);
+
+        SelenideElement adminPanelBtn = $("a[href='/trainerPanel']");
+        adminPanelBtn.click();
+
+        sleep(1000);
+
+        SelenideElement profileBtn = $("a[href='/trainerCoachNotes']");
+        profileBtn.click();
+
+        sleep(1000);
+
+        SelenideElement createInvoiceButton = $("button[type='ddelete']");
+        createInvoiceButton.click();
+
+        sleep(1000);
+
+        Alert alert = switchTo().alert();
+
+        alert.accept();
+
+        sleep(1000);
+    }
+
 }

--- a/src/test/java/com/fitwsarah/fitwsarah/coachnotesubdomain/businesslayer/CoachNoteServiceImplTest.java
+++ b/src/test/java/com/fitwsarah/fitwsarah/coachnotesubdomain/businesslayer/CoachNoteServiceImplTest.java
@@ -133,4 +133,28 @@ public class CoachNoteServiceImplTest {
         assertThrows(EntityNotFoundException.class, () -> coachNoteService.updateCoachNoteById(nonExistingId, updateRequest));
     }
 
+    @Test
+    public void deteleCoachNoteById_ShouldSucceed() {
+        // Arrange
+        String existingId = "existingId";
+        CoachNote existingCoachNote = new CoachNote();
+        when(coachNoteRepository.findCoachNoteByCoachNoteIdentifier_CoachNoteId(existingId)).thenReturn(existingCoachNote);
+
+        // Act
+        coachNoteService.deleteCoachNoteById(existingId);
+
+        // Assert
+        verify(coachNoteRepository).delete(existingCoachNote);
+    }
+
+    @Test
+    public void deteleCoachNoteById_ThrowsException_WhenNotFound() {
+        // Arrange
+        String nonExistingId = "nonExistingId";
+        when(coachNoteRepository.findCoachNoteByCoachNoteIdentifier_CoachNoteId(nonExistingId)).thenReturn(null);
+
+        // Act & Assert
+        assertThrows(EntityNotFoundException.class, () -> coachNoteService.deleteCoachNoteById(nonExistingId));
+    }
+
 }

--- a/src/test/java/com/fitwsarah/fitwsarah/coachnotesubdomain/presentationlayer/CoachNoteControllerIntegrationTest.java
+++ b/src/test/java/com/fitwsarah/fitwsarah/coachnotesubdomain/presentationlayer/CoachNoteControllerIntegrationTest.java
@@ -88,6 +88,16 @@ public class CoachNoteControllerIntegrationTest {
                 .andExpect(status().isOk());
     }
 
+    @Test
+    public void deleteCoachNoteByIdTest() throws Exception {
+        String coachNoteId = "testCoachNoteId";
+
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/coachnotes/" + coachNoteId)
+                        .header("Authorization", testToken)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
     private String asJsonString(Object obj) throws JsonProcessingException {
         ObjectMapper objectMapper = new ObjectMapper();
         return objectMapper.writeValueAsString(obj);

--- a/src/test/java/com/fitwsarah/fitwsarah/coachnotesubdomain/presentationlayer/CoachNoteControllerUnitTest.java
+++ b/src/test/java/com/fitwsarah/fitwsarah/coachnotesubdomain/presentationlayer/CoachNoteControllerUnitTest.java
@@ -12,7 +12,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ActiveProfiles("test")
 public class CoachNoteControllerUnitTest {
@@ -77,4 +77,25 @@ public class CoachNoteControllerUnitTest {
 
         assertEquals(expectedResponse, actualResponse);
     }
+
+    @Test
+    public void deleteCoachNoteByIdTest() {
+        String coachNoteId = "sadsads";
+
+        // Call the method under test
+        coachNoteController.deleteCoachNoteById(coachNoteId);
+
+        // Verify that the service method was called once with the correct id
+        verify(coachNoteService, times(1)).deleteCoachNoteById(coachNoteId);
+    }
+
+    @Test
+    public void deleteCoachNoteByIdReturnExceptionNotFoundTest(){
+            String coachNoteId = "sadsads";
+        doThrow(new RuntimeException("CoachNote not found")).when(coachNoteService).deleteCoachNoteById(coachNoteId);
+        try {
+            coachNoteController.deleteCoachNoteById(coachNoteId);
+        } catch (RuntimeException e) {
+            assertEquals("CoachNote not found", e.getMessage());
+        } }
 }


### PR DESCRIPTION
**JIRA: link to jira ticket**
https://champlainsaintlambert.atlassian.net/browse/FWS-94

**What is the ticket about and why are we making this change?**

This ticket concerns being able to delete a coach note by its ID in the system from the admin/trainer panel. This ticket is important because as an admin/trainer, I want to be able to delete a coach's notes if I don't want them to be in the system.

**What are the various changes and what other modules do those changes affect?**
 
-3 types of testing
-Selenium Test
-backend for the deleteCoachNotesById
-Front end for the deleteCoachNotesById
-Added both Admin/Trainer panel invoice delete button for each invoice
- Added Window alert before completely deleting.

**UI Change:**
Before Trainer Coach Notes:

After Trainer Coach Notes:
![image](https://github.com/AlexeiTimbro/FitWSarah/assets/57909059/119f7d78-166b-4214-825c-8000bf22acdf)

After clicking delete  Coach Notes:
![image](https://github.com/AlexeiTimbro/FitWSarah/assets/57909059/dc77934c-7880-4c81-8fb1-588a06c1bfc8)

After deleting:
![image](https://github.com/AlexeiTimbro/FitWSarah/assets/57909059/167d324c-3335-4821-aa1c-f18c0058c9fe)









